### PR TITLE
feature gate the runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 .cargo
 .env
 Cargo.lock
+
+# all the key files
+*.key

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,8 @@ assert_cmd = "2.0"
 sp-storage = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
+default = ["polkadot", "kusama", "westend"]
 slow-tests = []
+westend = []
+polkadot = []
+kusama = []

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -114,6 +114,7 @@ pub mod static_types {
 	pub use max_weight::MaxWeight;
 }
 
+#[cfg(feature = "westend")]
 pub mod westend {
 	use super::*;
 
@@ -214,6 +215,7 @@ pub mod westend {
 	}
 }
 
+#[cfg(feature = "polkadot")]
 pub mod polkadot {
 	use super::*;
 
@@ -314,6 +316,7 @@ pub mod polkadot {
 	}
 }
 
+#[cfg(feature = "kusama")]
 pub mod kusama {
 	use super::*;
 

--- a/src/dry_run.rs
+++ b/src/dry_run.rs
@@ -24,7 +24,6 @@ use codec::Encode;
 macro_rules! dry_run_cmd_for {
 	($runtime:tt) => {
 		paste::paste! {
-
 			pub async fn [<run_$runtime>](api: SubxtClient, config: DryRunConfig) -> Result<(), Error> {
 				use crate::chain::[<$runtime>]::runtime as runtime;
 
@@ -80,6 +79,9 @@ macro_rules! dry_run_cmd_for {
 	};
 }
 
+#[cfg(feature = "polkadot")]
 dry_run_cmd_for!(polkadot);
+#[cfg(feature = "kusama")]
 dry_run_cmd_for!(kusama);
+#[cfg(feature = "westend")]
 dry_run_cmd_for!(westend);

--- a/src/emergency_solution.rs
+++ b/src/emergency_solution.rs
@@ -31,6 +31,9 @@ macro_rules! emergency_cmd_for {
 	};
 }
 
+#[cfg(feature = "polkadot")]
 emergency_cmd_for!(polkadot);
+#[cfg(feature = "kusama")]
 emergency_cmd_for!(kusama);
+#[cfg(feature = "westend")]
 emergency_cmd_for!(westend);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -147,6 +147,9 @@ macro_rules! helpers_for_runtime {
 	};
 }
 
+#[cfg(feature = "polkadot")]
 helpers_for_runtime!(polkadot);
+#[cfg(feature = "kusama")]
 helpers_for_runtime!(kusama);
+#[cfg(feature = "westend")]
 helpers_for_runtime!(westend);

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,6 @@ async fn run_command(fut: BoxFuture<'_, Result<(), Error>>) -> Result<(), Error>
 #[cfg(not(unix))]
 async fn run_command(fut: BoxFuture<'_, Result<(), Error>>) -> Result<(), E> {
 	use tokio::signal::ctrl_c;
-
 	select! {
 		_ = ctrl_c() => {},
 		res = fut => res,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -14,7 +14,6 @@ use tokio::sync::Mutex;
 macro_rules! monitor_cmd_for {
 	($runtime:tt) => {
 		paste::paste! {
-
 			/// The monitor command.
 			pub async fn [<run_$runtime>] (api: SubxtClient, config: MonitorConfig) -> Result<(), Error> {
 				use crate::chain::[<$runtime>]::{self as chain, runtime};
@@ -351,8 +350,11 @@ macro_rules! monitor_cmd_for {
 	}
 }
 
+#[cfg(feature = "polkadot")]
 monitor_cmd_for!(polkadot);
+#[cfg(feature = "kusama")]
 monitor_cmd_for!(kusama);
+#[cfg(feature = "westend")]
 monitor_cmd_for!(westend);
 
 fn kill_main_task_if_critical_err(tx: &tokio::sync::mpsc::UnboundedSender<Error>, err: Error) {
@@ -371,8 +373,8 @@ fn kill_main_task_if_critical_err(tx: &tokio::sync::mpsc::UnboundedSender<Error>
 					tx.send(Error::Subxt(SubxtError::Rpc(RpcError::Call(CallError::Custom(e)))));
 			}
 		},
-		Error::Subxt(SubxtError::Rpc(RpcError::RequestTimeout)) |
-		Error::Subxt(SubxtError::Rpc(RpcError::Call(CallError::Failed(_)))) => (),
+		Error::Subxt(SubxtError::Rpc(RpcError::RequestTimeout))
+		| Error::Subxt(SubxtError::Rpc(RpcError::Call(CallError::Failed(_)))) => (),
 		// Regard the rest of subxt errors has fatal (including rpc)
 		Error::Subxt(e) => {
 			let _ = tx.send(Error::Subxt(e));

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -373,8 +373,8 @@ fn kill_main_task_if_critical_err(tx: &tokio::sync::mpsc::UnboundedSender<Error>
 					tx.send(Error::Subxt(SubxtError::Rpc(RpcError::Call(CallError::Custom(e)))));
 			}
 		},
-		Error::Subxt(SubxtError::Rpc(RpcError::RequestTimeout))
-		| Error::Subxt(SubxtError::Rpc(RpcError::Call(CallError::Failed(_)))) => (),
+		Error::Subxt(SubxtError::Rpc(RpcError::RequestTimeout)) |
+		Error::Subxt(SubxtError::Rpc(RpcError::Call(CallError::Failed(_)))) => (),
 		// Regard the rest of subxt errors has fatal (including rpc)
 		Error::Subxt(e) => {
 			let _ = tx.send(Error::Subxt(e));

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -34,19 +34,61 @@ macro_rules! any_runtime {
 	($chain:tt, $($code:tt)*) => {
 		match $chain {
 			Chain::Polkadot => {
-				#[allow(unused)]
-				use {$crate::monitor::run_polkadot as monitor_cmd, $crate::dry_run::run_polkadot as dry_run_cmd, $crate::emergency_solution::run_polkadot as emergency_cmd, $crate::helpers::update_runtime_constants_polkadot as tls_update_runtime_constants, $crate::chain::polkadot::runtime};
-				$($code)*
+				#[cfg(feature = "polkadot")]
+				{
+					#[allow(unused)]
+					use {
+						$crate::monitor::run_polkadot as monitor_cmd,
+						$crate::dry_run::run_polkadot as dry_run_cmd,
+						$crate::emergency_solution::run_polkadot as emergency_cmd,
+						$crate::helpers::update_runtime_constants_polkadot as tls_update_runtime_constants,
+						$crate::chain::polkadot::runtime
+					};
+					$($code)*
+			}
+
+			#[cfg(not(feature = "polkadot"))]
+			{
+				panic!("polkadot feature is not enabled, but target chain is polkadot")
+			}
 			},
 			Chain::Kusama => {
-				#[allow(unused)]
-				use {$crate::monitor::run_kusama as monitor_cmd, $crate::dry_run::run_kusama as dry_run_cmd, $crate::emergency_solution::run_kusama as emergency_cmd, $crate::helpers::update_runtime_constants_kusama as tls_update_runtime_constants, $crate::chain::kusama::runtime};
-				$($code)*
+				#[cfg(feature = "kusama")]
+				{
+					#[allow(unused)]
+					use {
+						$crate::monitor::run_kusama as monitor_cmd,
+						$crate::dry_run::run_kusama as dry_run_cmd,
+						$crate::emergency_solution::run_kusama as emergency_cmd,
+						$crate::helpers::update_runtime_constants_kusama as tls_update_runtime_constants,
+						$crate::chain::kusama::runtime
+					};
+					$($code)*
+				}
+
+				#[cfg(not(feature = "kusama"))]
+				{
+					panic!("kusama feature is not enabled, but target chain is kusama")
+				}
 			},
 			Chain::Westend => {
-				#[allow(unused)]
-				use {$crate::monitor::run_westend as monitor_cmd, $crate::dry_run::run_westend as dry_run_cmd, $crate::emergency_solution::run_westend as emergency_cmd, $crate::helpers::update_runtime_constants_westend as tls_update_runtime_constants, $crate::chain::westend::runtime};
-				$($code)*
+				#[cfg(feature = "westend")]
+				{
+					#[allow(unused)]
+					use {
+						$crate::monitor::run_westend as monitor_cmd,
+						$crate::dry_run::run_westend as dry_run_cmd,
+						$crate::emergency_solution::run_westend as emergency_cmd,
+						$crate::helpers::update_runtime_constants_westend as tls_update_runtime_constants,
+						$crate::chain::westend::runtime
+					};
+					$($code)*
+				}
+
+				#[cfg(not(feature = "westend"))]
+				{
+					panic!("westend feature is not enabled, but target chain is westend")
+				}
 			}
 		}
 	}
@@ -99,6 +141,7 @@ frame_support::parameter_types! {
 	pub static Balancing: Option<BalancingConfig> = Some( BalancingConfig { iterations: BalanceIterations::get(), tolerance: 0 } );
 }
 
+/// The chain being used.
 #[derive(Debug, Copy, Clone)]
 pub enum Chain {
 	Westend,


### PR DESCRIPTION
single runtime
```
cargo remote run -- --release --no-default-features --features kusama  0.95s user 0.18s system 1% cpu 1:28.15 total
```

all runtimes
```
cargo remote run -- --release  0.95s user 0.18s system 0% cpu 2:13.09 total
```

specially useful if we add a node-runtime as well.

