### PR TITLE
fix: update metadata on upgrades

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -41,7 +41,7 @@ macro_rules! any_runtime {
 						$crate::monitor::run_polkadot as monitor_cmd,
 						$crate::dry_run::run_polkadot as dry_run_cmd,
 						$crate::emergency_solution::run_polkadot as emergency_cmd,
-						$crate::helpers::update_runtime_constants_polkadot as tls_update_runtime_constants,
+						$crate::helpers::update_runtime_constants_polkadot as update_runtime_constants,
 						$crate::chain::polkadot::runtime
 					};
 					$($code)*
@@ -60,7 +60,7 @@ macro_rules! any_runtime {
 						$crate::monitor::run_kusama as monitor_cmd,
 						$crate::dry_run::run_kusama as dry_run_cmd,
 						$crate::emergency_solution::run_kusama as emergency_cmd,
-						$crate::helpers::update_runtime_constants_kusama as tls_update_runtime_constants,
+						$crate::helpers::update_runtime_constants_kusama as update_runtime_constants,
 						$crate::chain::kusama::runtime
 					};
 					$($code)*
@@ -79,7 +79,7 @@ macro_rules! any_runtime {
 						$crate::monitor::run_westend as monitor_cmd,
 						$crate::dry_run::run_westend as dry_run_cmd,
 						$crate::emergency_solution::run_westend as emergency_cmd,
-						$crate::helpers::update_runtime_constants_westend as tls_update_runtime_constants,
+						$crate::helpers::update_runtime_constants_westend as update_runtime_constants,
 						$crate::chain::westend::runtime
 					};
 					$($code)*

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -184,6 +184,10 @@ mod hidden {
 		))
 		.unwrap()
 	});
+
+	// TODO: https://github.com/paritytech/subxt/issues/652 not possible to know when a runtime upgrade
+	// is performed.
+	#[allow(unused)]
 	static RUNTIME_UPGRADES: Lazy<Counter> = Lazy::new(|| {
 		register_counter!(opts!(
 			"staking_miner_runtime_upgrades",
@@ -195,6 +199,9 @@ mod hidden {
 
 	// Exported wrappers.
 
+	// TODO: https://github.com/paritytech/subxt/issues/652 not possible to know when a runtime upgrade
+	// is performed.
+	#[allow(unused)]
 	pub fn on_runtime_upgrade() {
 		RUNTIME_UPGRADES.inc();
 	}


### PR DESCRIPTION
Currently when the miner starts up it fetches the constants that are needed and subxt compares these "to the metadata on the connected node" but on runtime upgrades those are never updated these which this PR fixes.