### PR TITLE
Fix CI timeout issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,7 @@ nightly-test-notification:
   needs:                           ["nightly-test"]
   when:                            always
   script:
-    - TEST_JOB_STATUS=$(<nightly_test_result)
+    - \[ ! -f nightly_test_result \] && TEST_JOB_STATUS=failed || TEST_JOB_STATUS=$(<nightly_test_result)
     - 'curl
         -X POST
         -H "Accept: application/vnd.github+json"


### PR DESCRIPTION
Addresses https://github.com/paritytech/staking-miner-v2/issues/406

Because of the GitLab CI specifics, when the `nightly-test` job fails due to timeout, an `after_script` section is not executed. And an artifact with job status is not created.
Workaround: test whether file `nightly_test_result` exists and if not then report `nightly-test` as failed, else read `nightly-test` status from artifact `nightly_test_result` file