### PR TITLE
feat: add prometheus metric `submission_interval`

### DIFF
--- a/src/epm.rs
+++ b/src/epm.rs
@@ -55,19 +55,21 @@ pub(crate) async fn update_metadata_constants(api: &SubxtClient) -> Result<(), E
 	const SIGNED_MAX_WEIGHT: Constant = Constant::new(EPM_PALLET_NAME, "SignedMaxWeight");
 	const MAX_LENGTH: Constant = Constant::new(EPM_PALLET_NAME, "MinerMaxLength");
 	const MAX_VOTES_PER_VOTER: Constant = Constant::new(EPM_PALLET_NAME, "MinerMaxVotesPerVoter");
+	const EPOCH_DURATION: Constant = Constant::new("Babe", "EpochDuration");
+	const SESSIONS_PER_ERA: Constant = Constant::new("Staking", "SessionsPerEra");
 
 	// TODO: no constant is exposed directly for this, hardcoded for now.
 	const SLOT_DURATION_SECS: u32 = 6;
-	const EPOCH_DURATION: Constant = Constant::new("Babe", "EpochDuration");
-	const SESSIONS_PER_ERA: Constant = Constant::new("Staking", "SessionsPerEra");
 
 	let max_weight = read_constant::<Weight>(api, SIGNED_MAX_WEIGHT)?;
 	let max_length: u32 = read_constant(api, MAX_LENGTH)?;
 	let max_votes_per_voter: u32 = read_constant(api, MAX_VOTES_PER_VOTER)?;
-	let epoch: u32 = read_constant(api, EPOCH_DURATION)?;
-	let sessions: u32 = read_constant(api, SESSIONS_PER_ERA)?;
-	// era = epoch * sessions * slot
-	let era_hours: u32 = (epoch * sessions * SLOT_DURATION_SECS) / (60 * 60);
+	// session == epoch
+	let session: u32 = read_constant(api, EPOCH_DURATION)?;
+	let num_sessions_per_era: u32 = read_constant(api, SESSIONS_PER_ERA)?;
+
+	// era = session * seconds per slot * number sessions per era
+	let era_hours: u32 = (session * SLOT_DURATION_SECS * num_sessions_per_era) / (60 * 60);
 
 	log::trace!(
 		target: LOG_TARGET,

--- a/src/epm.rs
+++ b/src/epm.rs
@@ -69,7 +69,8 @@ pub(crate) async fn update_metadata_constants(api: &SubxtClient) -> Result<(), E
 	let num_sessions_per_era: u32 = read_constant(api, SESSIONS_PER_ERA)?;
 
 	// era = session * seconds per slot * number sessions per era
-	let era_hours: u32 = (session * SLOT_DURATION_SECS * num_sessions_per_era) / (60 * 60);
+	let submission_interval_hours: u32 =
+		(session * SLOT_DURATION_SECS * num_sessions_per_era) / (60 * 60);
 
 	log::trace!(
 		target: LOG_TARGET,
@@ -89,13 +90,16 @@ pub(crate) async fn update_metadata_constants(api: &SubxtClient) -> Result<(), E
 		MAX_VOTES_PER_VOTER.to_string(),
 		max_votes_per_voter
 	);
-	log::trace!(target: LOG_TARGET, "updating metadata constant `Era`: `{}h`", era_hours);
+	log::trace!(
+		target: LOG_TARGET,
+		"updating metadata constant `Era`: `{submission_interval_hours}h`"
+	);
 
 	static_types::MaxWeight::set(max_weight);
 	static_types::MaxLength::set(max_length);
 	static_types::MaxVotesPerVoter::set(max_votes_per_voter);
-	static_types::Era::set(era_hours);
-	prometheus::set_era(era_hours);
+	static_types::SubmissionInterval::set(submission_interval_hours);
+	prometheus::set_submission_interval(submission_interval_hours);
 
 	Ok(())
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -161,6 +161,13 @@ mod hidden {
 		register_gauge!(opts!("staking_miner_solution_weight", "Weight of the solution submitted"))
 			.unwrap()
 	});
+	static ERA: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(opts!(
+			"staking_miner_era_hours",
+			"The time in hours between each era (election) occurs"
+		))
+		.unwrap()
+	});
 
 	pub fn on_runtime_upgrade() {
 		RUNTIME_UPGRADES.inc();
@@ -190,6 +197,10 @@ mod hidden {
 		SCORE_MINIMAL_STAKE.set(score.minimal_stake as f64);
 		SCORE_SUM_STAKE.set(score.sum_stake as f64);
 		SCORE_SUM_STAKE_SQUARED.set(score.sum_stake_squared as f64);
+	}
+
+	pub fn set_era(era: u32) {
+		ERA.set(era as f64);
 	}
 
 	pub fn observe_submit_and_watch_duration(time: f64) {

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -163,8 +163,8 @@ mod hidden {
 	});
 	static ERA: Lazy<Gauge> = Lazy::new(|| {
 		register_gauge!(opts!(
-			"staking_miner_era_hours",
-			"The time in hours between each era (election) occurs"
+			"staking_miner_submission_interval_hours",
+			"The time in hours between each submission occurs",
 		))
 		.unwrap()
 	});
@@ -199,7 +199,7 @@ mod hidden {
 		SCORE_SUM_STAKE_SQUARED.set(score.sum_stake_squared as f64);
 	}
 
-	pub fn set_era(era: u32) {
+	pub fn set_submission_interval(era: u32) {
 		ERA.set(era as f64);
 	}
 

--- a/src/static_types.rs
+++ b/src/static_types.rs
@@ -79,7 +79,7 @@ mod max_weight {
 
 impl_atomic_u32_parameter_types!(max_length, MaxLength);
 impl_atomic_u32_parameter_types!(max_votes, MaxVotesPerVoter);
-impl_atomic_u32_parameter_types!(era, Era);
+impl_atomic_u32_parameter_types!(submission_interval, SubmissionInterval);
 pub use max_weight::MaxWeight;
 
 pub mod westend {

--- a/src/static_types.rs
+++ b/src/static_types.rs
@@ -79,6 +79,7 @@ mod max_weight {
 
 impl_atomic_u32_parameter_types!(max_length, MaxLength);
 impl_atomic_u32_parameter_types!(max_votes, MaxVotesPerVoter);
+impl_atomic_u32_parameter_types!(era, Era);
 pub use max_weight::MaxWeight;
 
 pub mod westend {


### PR DESCRIPTION
Close #459 

Each chain has different configurations how often an election occurs and this PR adds functionality to read the associated constants to calculate it.

Staking miner will update these on startup and on each runtime upgrade. 