### PR TITLE
ci: add ci job to publish docker image description

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,3 +213,20 @@ build-push-image:
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
   after_script:
     - buildah logout --all
+
+publish-docker-image-description:
+  stage:                           publish
+  <<:                              *kubernetes-env
+  image:                           paritytech/dockerhub-description
+  variables:
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
+    DOCKERHUB_REPOSITORY:          paritytech/staking-miner-v2
+    SHORT_DESCRIPTION:             "staking-miner-v2"
+  rules:
+  - if: $CI_COMMIT_REF_NAME == "main"
+    changes:
+    - Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -1,0 +1,3 @@
+# staking-miner-v2
+
+[GitHub](https://github.com/paritytech/staking-miner-v2)


### PR DESCRIPTION
Added CI job to publish Docker image description to [hub.docker.com](https://hub.docker.com/r/paritytech/staking-miner-v2)
Description can be updated in a `Dockerfile.README.md` file in a repository root and as soon it will be merged into `main` branch its content will get published to [hub.docker.com](https://hub.docker.com/r/paritytech/staking-miner-v2)

Related to https://github.com/paritytech/ci_cd/issues/741