### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This is a patch release that fixes a bug which takes the `Weight::proof_size` in
 ### Compatibility
 Tested against:
 - Polkadot v9370
-- Kusama v9370
+- Kusama v9390
 - Westend v9390
 
 ## [v0.1.2] - 2022-01-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.1.3] - 2022-03-21
+
+This is a patch release that fixes a bug which takes the `Weight::proof_size` into account.
+
+### Fixed
+- fix: use `Weight::proof_size`  ([#481](https://github.com/paritytech/staking-miner-v2/pull/481))
+
+### Changed
+- chore: upgrade subxt v0.27  ([#464](https://github.com/paritytech/staking-miner-v2/pull/464))
+- chore(deps): bump once_cell from 1.17.0 to 1.17.1  ([#463](https://github.com/paritytech/staking-miner-v2/pull/463))
+- chore(deps): bump secp256k1 in /staking-miner-playground  ([#470](https://github.com/paritytech/staking-miner-v2/pull/470))
+- chore(deps): bump tokio in /staking-miner-playground  ([#471](https://github.com/paritytech/staking-miner-v2/pull/471))
+- chore: adjust ci staking-miner-playground  ([#469](https://github.com/paritytech/staking-miner-v2/pull/469))
+- chore(deps): bump paste from 1.0.11 to 1.0.12  ([#477](https://github.com/paritytech/staking-miner-v2/pull/477))
+- chore(deps): bump thiserror from 1.0.38 to 1.0.39  ([#478](https://github.com/paritytech/staking-miner-v2/pull/478))
+- chore(deps): bump serde_json from 1.0.93 to 1.0.94  ([#479](https://github.com/paritytech/staking-miner-v2/pull/479))
+- chore(deps): bump tokio from 1.25.0 to 1.26.0  ([#476](https://github.com/paritytech/staking-miner-v2/pull/476))
+- chore(deps): bump assert_cmd from 2.0.9 to 2.0.10  ([#493](https://github.com/paritytech/staking-miner-v2/pull/493))
+- chore(deps): bump assert_cmd from 2.0.8 to 2.0.9  ([#492](https://github.com/paritytech/staking-miner-v2/pull/492))
+- chore(deps): bump serde from 1.0.155 to 1.0.156  ([#490](https://github.com/paritytech/staking-miner-v2/pull/490))
+- chore(deps): bump serde from 1.0.154 to 1.0.155  ([#487](https://github.com/paritytech/staking-miner-v2/pull/487))
+- chore(deps): bump hyper from 0.14.24 to 0.14.25  ([#488](https://github.com/paritytech/staking-miner-v2/pull/488))
+- chore(deps): bump futures from 0.3.26 to 0.3.27  ([#489](https://github.com/paritytech/staking-miner-v2/pull/489))
+- chore(deps): bump serde from 1.0.153 to 1.0.154  ([#486](https://github.com/paritytech/staking-miner-v2/pull/486))
+- chore: remove unused dependencies  ([#485](https://github.com/paritytech/staking-miner-v2/pull/485))
+- chore(deps): bump wasmtime from 5.0.0 to 5.0.1  ([#484](https://github.com/paritytech/staking-miner-v2/pull/484))
+- chore(deps): bump serde from 1.0.152 to 1.0.153  ([#482](https://github.com/paritytech/staking-miner-v2/pull/482))
+- Bump hyper from 0.14.23 to 0.14.24  ([#457](https://github.com/paritytech/staking-miner-v2/pull/457))
+- Bump serde_json from 1.0.91 to 1.0.93  ([#460](https://github.com/paritytech/staking-miner-v2/pull/460))
+- Bump futures from 0.3.25 to 0.3.26  ([#456](https://github.com/paritytech/staking-miner-v2/pull/456))
+- Bump tokio from 1.24.2 to 1.25.0  ([#455](https://github.com/paritytech/staking-miner-v2/pull/455))
+- Bump bumpalo from 3.10.0 to 3.12.0  ([#453](https://github.com/paritytech/staking-miner-v2/pull/453))
+- Bump tokio from 1.24.1 to 1.24.2  ([#452](https://github.com/paritytech/staking-miner-v2/pull/452))
+
+### Compatibility
+Tested against:
+- Polkadot v9370
+- Kusama v9370
+- Westend v9390
+
 ## [v0.1.2] - 2022-01-11
 
 This is a release that adds a couple of new features/CLI options, a useful one is `--dry-run` which will check the validity of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This is a patch release that fixes a bug which takes the `Weight::proof_size` in
 
 ### Compatibility
 Tested against:
-- Polkadot v9370
+- Polkadot v9390
 - Kusama v9390
 - Westend v9390
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking-miner"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
polkadot v0.9.40 will be a breaking release.

So let's release this bug fix and then merge in the breaking stuff that work on versions < v0.9.40