### PR TITLE
fix: update Cargo.lock for v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,7 +3549,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staking-miner"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_cmd",
  "clap",


### PR DESCRIPTION
Cargo.lock wasn't updated for the v0.1.3 release, [breaking ci](https://gitlab.parity.io/parity/mirrors/staking-miner-v2/-/jobs/2567351).