### PR TITLE
use stable rust for cargo clippy and doc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ clippy:
   <<:                              *docker-env
   <<:                              *common-refs
   script:
-    - cargo +nightly clippy --all-targets
+    - cargo clippy --all-targets
 
 check-docs:
   stage:                           check
@@ -83,7 +83,7 @@ check-docs:
   <<:                              *common-refs
   script:
     - RUSTDOCFLAGS="--cfg docsrs --deny rustdoc::broken_intra_doc_links"
-        cargo +nightly doc --verbose --workspace --no-deps --document-private-items --all-features
+        cargo doc --verbose --workspace --no-deps --document-private-items --all-features
 
 check-code:
   stage:                           check


### PR DESCRIPTION
We're in the process of phasing out the nightly rust toolchain from ci-linux, and stable seems to be sufficient for these jobs.