### PR TITLE
`commands` module to expose each sub-command, and put options next to them

### DIFF
--- a/src/commands/dry_run.rs
+++ b/src/commands/dry_run.rs
@@ -18,8 +18,35 @@
 
 use pallet_election_provider_multi_phase::RawSolution;
 
-use crate::{epm, error::Error, opt::DryRunConfig, prelude::*, signer::Signer, static_types};
+use crate::{epm, error::Error, opt::Solver, prelude::*, signer::Signer, static_types};
+use clap::Parser;
 use codec::Encode;
+
+#[derive(Debug, Clone, Parser)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct DryRunConfig {
+	/// The block hash at which scraping happens. If none is provided, the latest head is used.
+	#[clap(long)]
+	pub at: Option<Hash>,
+
+	/// The solver algorithm to use.
+	#[clap(subcommand)]
+	pub solver: Solver,
+
+	/// Force create a new snapshot, else expect one to exist onchain.
+	#[clap(long)]
+	pub force_snapshot: bool,
+
+	/// The path to a file containing the seed of the account. If the file is not found, the seed is
+	/// used as-is.
+	///
+	/// Can also be provided via the `SEED` environment variable.
+	///
+	/// WARNING: Don't use an account with a large stash for this. Based on how the bot is
+	/// configured, it might re-try and lose funds through transaction fees/deposits.
+	#[clap(long, short, env = "SEED")]
+	pub seed_or_path: String,
+}
 
 pub async fn dry_run_cmd<T>(api: SubxtClient, config: DryRunConfig) -> Result<(), Error>
 where

--- a/src/commands/emergency_solution.rs
+++ b/src/commands/emergency_solution.rs
@@ -16,9 +16,25 @@
 
 //! The emergency-solution command.
 
-use crate::{opt::EmergencySolutionConfig, prelude::*, static_types};
+use crate::{error::Error, opt::Solver, prelude::*, static_types};
+use clap::Parser;
 
-pub async fn emergency_cmd<T>(
+#[derive(Debug, Clone, Parser)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct EmergencySolutionConfig {
+	/// The block hash at which scraping happens. If none is provided, the latest head is used.
+	#[clap(long)]
+	pub at: Option<Hash>,
+
+	/// The solver algorithm to use.
+	#[clap(subcommand)]
+	pub solver: Solver,
+
+	/// The number of top backed winners to take. All are taken, if not provided.
+	pub take: Option<usize>,
+}
+
+pub async fn emergency_solution_cmd<T>(
 	_api: SubxtClient,
 	_config: EmergencySolutionConfig,
 ) -> Result<(), Error>

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,7 @@
+pub mod dry_run;
+pub mod emergency_solution;
+pub mod monitor;
+
+pub use dry_run::{dry_run_cmd, DryRunConfig};
+pub use emergency_solution::{emergency_solution_cmd, EmergencySolutionConfig};
+pub use monitor::{monitor_cmd, MonitorConfig};

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -18,23 +18,145 @@ use crate::{
 	epm,
 	error::Error,
 	helpers::{kill_main_task_if_critical_err, TimedFuture},
-	opt::{Listen, MonitorConfig, SubmissionStrategy},
+	opt::Solver,
 	prelude::*,
 	prometheus,
 	signer::Signer,
 	static_types,
 };
+use clap::Parser;
 use codec::{Decode, Encode};
 use frame_election_provider_support::NposSolution;
 use futures::future::TryFutureExt;
 use jsonrpsee::{core::Error as JsonRpseeError, types::error::CallError};
 use pallet_election_provider_multi_phase::{RawSolution, SolutionOf};
 use sp_runtime::Perbill;
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 use subxt::{
 	config::Header as _, error::RpcError, rpc::Subscription, tx::TxStatus, Error as SubxtError,
 };
 use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Parser)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct MonitorConfig {
+	/// They type of event to listen to.
+	///
+	/// Typically, finalized is safer and there is no chance of anything going wrong, but it can be
+	/// slower. It is recommended to use finalized, if the duration of the signed phase is longer
+	/// than the the finality delay.
+	#[clap(long, value_enum, default_value_t = Listen::Head)]
+	pub listen: Listen,
+
+	/// The solver algorithm to use.
+	#[clap(subcommand)]
+	pub solver: Solver,
+
+	/// Submission strategy to use.
+	///
+	/// Possible options:
+	///
+	/// `--submission-strategy if-leading`: only submit if leading.
+	///
+	/// `--submission-strategy always`: always submit.
+	///
+	/// `--submission-strategy "percent-better <percent>"`: submit if the submission is `n` percent better.
+	///
+	/// `--submission-strategy "no-worse-than  <percent>"`: submit if submission is no more than `n` percent worse.
+	#[clap(long, parse(try_from_str), default_value = "if-leading")]
+	pub submission_strategy: SubmissionStrategy,
+
+	/// The path to a file containing the seed of the account. If the file is not found, the seed is
+	/// used as-is.
+	///
+	/// Can also be provided via the `SEED` environment variable.
+	///
+	/// WARNING: Don't use an account with a large stash for this. Based on how the bot is
+	/// configured, it might re-try and lose funds through transaction fees/deposits.
+	#[clap(long, short, env = "SEED")]
+	pub seed_or_path: String,
+
+	/// Delay in number seconds to wait until starting mining a solution.
+	///
+	/// At every block when a solution is attempted
+	/// a delay can be enforced to avoid submitting at
+	/// "same time" and risk potential races with other miners.
+	///
+	/// When this is enabled and there are competing solutions, your solution might not be submitted
+	/// if the scores are equal.
+	#[clap(long, default_value_t = 0)]
+	pub delay: usize,
+
+	/// Verify the submission by `dry-run` the extrinsic to check the validity.
+	/// If the extrinsic is invalid then the submission is ignored and the next block will attempted again.
+	///
+	/// This requires a RPC endpoint that exposes unsafe RPC methods, if the RPC endpoint doesn't expose unsafe RPC methods
+	/// then the miner will be terminated.
+	#[clap(long)]
+	pub dry_run: bool,
+}
+
+/// The type of event to listen to.
+///
+///
+/// Typically, finalized is safer and there is no chance of anything going wrong, but it can be
+/// slower. It is recommended to use finalized, if the duration of the signed phase is longer
+/// than the the finality delay.
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(clap::ValueEnum, Debug, Copy, Clone)]
+pub enum Listen {
+	/// Latest finalized head of the canonical chain.
+	Finalized,
+	/// Latest head of the canonical chain.
+	Head,
+}
+
+/// Submission strategy to use.
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum SubmissionStrategy {
+	/// Always submit.
+	Always,
+	// Submit if we are leading, or if the solution that's leading is more that the given `Perbill`
+	// better than us. This helps detect obviously fake solutions and still combat them.
+	/// Only submit if at the time, we are the best (or equal to it).
+	IfLeading,
+	/// Submit if we are no worse than `Perbill` worse than the best.
+	ClaimNoWorseThan(Perbill),
+	/// Submit if we are leading, or if the solution that's leading is more that the given `Perbill`
+	/// better than us. This helps detect obviously fake solutions and still combat them.
+	ClaimBetterThan(Perbill),
+}
+
+/// Custom `impl` to parse `SubmissionStrategy` from CLI.
+///
+/// Possible options:
+/// * --submission-strategy if-leading: only submit if leading
+/// * --submission-strategy always: always submit
+/// * --submission-strategy "percent-better <percent>": submit if submission is `n` percent better.
+///
+impl FromStr for SubmissionStrategy {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let s = s.trim();
+
+		let res = if s == "if-leading" {
+			Self::IfLeading
+		} else if s == "always" {
+			Self::Always
+		} else if let Some(percent) = s.strip_prefix("no-worse-than ") {
+			let percent: u32 = percent.parse().map_err(|e| format!("{:?}", e))?;
+			Self::ClaimNoWorseThan(Perbill::from_percent(percent))
+		} else if let Some(percent) = s.strip_prefix("percent-better ") {
+			let percent: u32 = percent.parse().map_err(|e| format!("{:?}", e))?;
+			Self::ClaimBetterThan(Perbill::from_percent(percent))
+		} else {
+			return Err(s.into())
+		};
+		Ok(res)
+	}
+}
 
 pub async fn monitor_cmd<T>(api: SubxtClient, config: MonitorConfig) -> Result<(), Error>
 where
@@ -539,5 +661,15 @@ mod tests {
 		assert!(score_passes_strategy(s(102), s(100), SubmissionStrategy::ClaimNoWorseThan(two)));
 		assert!(score_passes_strategy(s(103), s(100), SubmissionStrategy::ClaimNoWorseThan(two)));
 		assert!(score_passes_strategy(s(150), s(100), SubmissionStrategy::ClaimNoWorseThan(two)));
+	}
+
+	#[test]
+	fn submission_strategy_from_str_works() {
+		assert_eq!(SubmissionStrategy::from_str("if-leading"), Ok(SubmissionStrategy::IfLeading));
+		assert_eq!(SubmissionStrategy::from_str("always"), Ok(SubmissionStrategy::Always));
+		assert_eq!(
+			SubmissionStrategy::from_str("  percent-better 99   "),
+			Ok(SubmissionStrategy::ClaimBetterThan(Accuracy::from_percent(99)))
+		);
 	}
 }

--- a/src/epm.rs
+++ b/src/epm.rs
@@ -16,7 +16,13 @@
 
 //! Wrappers or helpers for [`pallet_election_provider_multi_phase`].
 
-use crate::{helpers::RuntimeDispatchInfo, opt::Solver, prelude::*, static_types};
+use crate::{
+	error::Error,
+	helpers::RuntimeDispatchInfo,
+	opt::{BalanceIterations, Balancing, Solver},
+	prelude::*,
+	static_types,
+};
 use codec::{Decode, Encode};
 use frame_election_provider_support::{NposSolution, PhragMMS, SequentialPhragmen};
 use frame_support::weights::Weight;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,10 @@
 
 #![allow(dead_code)]
 
-pub mod dry_run;
-pub mod emergency_solution;
+pub mod commands;
 pub mod epm;
 pub mod error;
 pub mod helpers;
-pub mod monitor;
 pub mod opt;
 pub mod prelude;
 pub mod prometheus;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,10 @@
 //!   development. It is intended to run this bot with a `restart = true` way, so that it reports it
 //!   crash, but resumes work thereafter.
 
-mod dry_run;
-mod emergency_solution;
+mod commands;
 mod epm;
 mod error;
 mod helpers;
-mod monitor;
 mod opt;
 mod prelude;
 mod prometheus;
@@ -41,13 +39,70 @@ mod signer;
 mod static_types;
 
 use clap::Parser;
+use error::Error;
 use futures::future::{BoxFuture, FutureExt};
 use jsonrpsee::ws_client::WsClientBuilder;
-use opt::Command;
 use prelude::*;
 use std::sync::Arc;
 use tokio::sync::oneshot;
 use tracing_subscriber::EnvFilter;
+
+#[derive(Debug, Clone, Parser)]
+#[cfg_attr(test, derive(PartialEq))]
+#[clap(author, version, about)]
+pub struct Opt {
+	/// The `ws` node to connect to.
+	#[clap(long, short, default_value = DEFAULT_URI, env = "URI")]
+	pub uri: String,
+
+	#[clap(subcommand)]
+	pub command: Command,
+
+	/// The prometheus endpoint TCP port.
+	#[clap(long, short, env = "PROMETHEUS_PORT")]
+	pub prometheus_port: Option<u16>,
+
+	/// Sets a custom logging filter. Syntax is `<target>=<level>`, e.g. -lstaking-miner=debug.
+	///
+	/// Log levels (least to most verbose) are error, warn, info, debug, and trace.
+	/// By default, all targets log `info`. The global log level can be set with `-l<level>`.
+	#[clap(long, short, default_value = "info")]
+	pub log: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum Command {
+	/// Monitor for the phase being signed, then compute.
+	Monitor(commands::MonitorConfig),
+	/// Just compute a solution now, and don't submit it.
+	DryRun(commands::DryRunConfig),
+	/// Provide a solution that can be submitted to the chain as an emergency response.
+	EmergencySolution(commands::EmergencySolutionConfig),
+}
+
+// A helper to use different MinerConfig depending on chain.
+macro_rules! any_runtime {
+	($chain:tt, $($code:tt)*) => {
+		match $chain {
+			$crate::opt::Chain::Polkadot => {
+				#[allow(unused)]
+				use $crate::static_types::polkadot::MinerConfig;
+				$($code)*
+			},
+			$crate::opt::Chain::Kusama => {
+				#[allow(unused)]
+				use $crate::static_types::kusama::MinerConfig;
+				$($code)*
+			},
+			$crate::opt::Chain::Westend => {
+				#[allow(unused)]
+				use $crate::static_types::westend::MinerConfig;
+				$($code)*
+			},
+		}
+	};
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -78,7 +133,7 @@ async fn main() -> Result<(), Error> {
 
 	let api = SubxtClient::from_rpc_client(Arc::new(rpc)).await?;
 	let runtime_version = api.rpc().runtime_version(None).await?;
-	let chain = Chain::try_from(runtime_version)?;
+	let chain = opt::Chain::try_from(runtime_version)?;
 	let _prometheus_handle = prometheus::run(prometheus_port.unwrap_or(DEFAULT_PROMETHEUS_PORT))
 		.map_err(|e| log::warn!("Failed to start prometheus endpoint: {}", e));
 	log::info!(target: LOG_TARGET, "Connected to chain: {}", chain);
@@ -93,10 +148,10 @@ async fn main() -> Result<(), Error> {
 
 	let res = any_runtime!(chain, {
 		let fut = match command {
-			Command::Monitor(cfg) => monitor::monitor_cmd::<MinerConfig>(api, cfg).boxed(),
-			Command::DryRun(cfg) => dry_run::dry_run_cmd::<MinerConfig>(api, cfg).boxed(),
+			Command::Monitor(cfg) => commands::monitor_cmd::<MinerConfig>(api, cfg).boxed(),
+			Command::DryRun(cfg) => commands::dry_run_cmd::<MinerConfig>(api, cfg).boxed(),
 			Command::EmergencySolution(cfg) =>
-				emergency_solution::emergency_cmd::<MinerConfig>(api, cfg).boxed(),
+				commands::emergency_solution_cmd::<MinerConfig>(api, cfg).boxed(),
 		};
 
 		run_command(fut, rx_upgrade).await
@@ -200,6 +255,7 @@ async fn runtime_upgrade_task(api: SubxtClient, tx: oneshot::Sender<Error>) {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use commands::monitor;
 
 	#[test]
 	fn cli_monitor_works() {
@@ -226,10 +282,10 @@ mod tests {
 				uri: "hi".to_string(),
 				prometheus_port: Some(9999),
 				log: "info".to_string(),
-				command: Command::Monitor(MonitorConfig {
-					listen: Listen::Head,
-					solver: Solver::SeqPhragmen { iterations: 10 },
-					submission_strategy: SubmissionStrategy::IfLeading,
+				command: Command::Monitor(commands::MonitorConfig {
+					listen: monitor::Listen::Head,
+					solver: opt::Solver::SeqPhragmen { iterations: 10 },
+					submission_strategy: monitor::SubmissionStrategy::IfLeading,
 					seed_or_path: "//Alice".to_string(),
 					delay: 12,
 					dry_run: false,
@@ -257,9 +313,9 @@ mod tests {
 				uri: "hi".to_string(),
 				prometheus_port: None,
 				log: "info".to_string(),
-				command: Command::DryRun(DryRunConfig {
+				command: Command::DryRun(commands::DryRunConfig {
 					at: None,
-					solver: Solver::PhragMMS { iterations: 10 },
+					solver: opt::Solver::PhragMMS { iterations: 10 },
 					force_snapshot: false,
 					seed_or_path: "//Alice".to_string(),
 				}),
@@ -287,24 +343,12 @@ mod tests {
 				uri: "hi".to_string(),
 				prometheus_port: None,
 				log: "info".to_string(),
-				command: Command::EmergencySolution(EmergencySolutionConfig {
+				command: Command::EmergencySolution(commands::EmergencySolutionConfig {
 					take: Some(99),
 					at: None,
-					solver: Solver::PhragMMS { iterations: 1337 },
+					solver: opt::Solver::PhragMMS { iterations: 1337 },
 				}),
 			}
-		);
-	}
-
-	#[test]
-	fn submission_strategy_from_str_works() {
-		use std::str::FromStr;
-
-		assert_eq!(SubmissionStrategy::from_str("if-leading"), Ok(SubmissionStrategy::IfLeading));
-		assert_eq!(SubmissionStrategy::from_str("always"), Ok(SubmissionStrategy::Always));
-		assert_eq!(
-			SubmissionStrategy::from_str("  percent-better 99   "),
-			Ok(SubmissionStrategy::ClaimBetterThan(Accuracy::from_percent(99)))
 		);
 	}
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,24 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{error::Error, prelude::*};
+use crate::error::Error;
 
 use clap::*;
 use sp_npos_elections::BalancingConfig;
-use sp_runtime::Perbill;
 use std::{fmt, str::FromStr};
 
-#[derive(Debug, Clone, Parser)]
-#[cfg_attr(test, derive(PartialEq))]
-pub enum Command {
-	/// Monitor for the phase being signed, then compute.
-	Monitor(MonitorConfig),
-	/// Just compute a solution now, and don't submit it.
-	DryRun(DryRunConfig),
-	/// Provide a solution that can be submitted to the chain as an emergency response.
-	EmergencySolution(EmergencySolutionConfig),
-}
-
+/// The type of solver to use.
+// A common option across multiple commands.
 #[derive(Debug, Clone, Parser)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum Solver {
@@ -43,76 +33,6 @@ pub enum Solver {
 		#[clap(long, default_value = "10")]
 		iterations: usize,
 	},
-}
-
-#[macro_export]
-macro_rules! any_runtime {
-	($chain:tt, $($code:tt)*) => {
-		match $chain {
-			Chain::Polkadot => {
-				#[allow(unused)]
-				use $crate::static_types::polkadot::MinerConfig;
-				$($code)*
-			},
-			Chain::Kusama => {
-				#[allow(unused)]
-				use $crate::static_types::kusama::MinerConfig;
-				$($code)*
-			},
-			Chain::Westend => {
-				#[allow(unused)]
-				use $crate::static_types::westend::MinerConfig;
-				$($code)*
-			},
-		}
-	};
-}
-
-/// Submission strategy to use.
-#[derive(Debug, Copy, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
-pub enum SubmissionStrategy {
-	/// Always submit.
-	Always,
-	// Submit if we are leading, or if the solution that's leading is more that the given `Perbill`
-	// better than us. This helps detect obviously fake solutions and still combat them.
-	/// Only submit if at the time, we are the best (or equal to it).
-	IfLeading,
-	/// Submit if we are no worse than `Perbill` worse than the best.
-	ClaimNoWorseThan(Perbill),
-	/// Submit if we are leading, or if the solution that's leading is more that the given `Perbill`
-	/// better than us. This helps detect obviously fake solutions and still combat them.
-	ClaimBetterThan(Perbill),
-}
-
-/// Custom `impl` to parse `SubmissionStrategy` from CLI.
-///
-/// Possible options:
-/// * --submission-strategy if-leading: only submit if leading
-/// * --submission-strategy always: always submit
-/// * --submission-strategy "percent-better <percent>": submit if submission is `n` percent better.
-///
-impl FromStr for SubmissionStrategy {
-	type Err = String;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		let s = s.trim();
-
-		let res = if s == "if-leading" {
-			Self::IfLeading
-		} else if s == "always" {
-			Self::Always
-		} else if let Some(percent) = s.strip_prefix("no-worse-than ") {
-			let percent: u32 = percent.parse().map_err(|e| format!("{:?}", e))?;
-			Self::ClaimNoWorseThan(Perbill::from_percent(percent))
-		} else if let Some(percent) = s.strip_prefix("percent-better ") {
-			let percent: u32 = percent.parse().map_err(|e| format!("{:?}", e))?;
-			Self::ClaimBetterThan(Perbill::from_percent(percent))
-		} else {
-			return Err(s.into())
-		};
-		Ok(res)
-	}
 }
 
 frame_support::parameter_types! {
@@ -128,21 +48,6 @@ pub enum Chain {
 	Westend,
 	Kusama,
 	Polkadot,
-}
-
-/// The type of event to listen to.
-///
-///
-/// Typically, finalized is safer and there is no chance of anything going wrong, but it can be
-/// slower. It is recommended to use finalized, if the duration of the signed phase is longer
-/// than the the finality delay.
-#[cfg_attr(test, derive(PartialEq))]
-#[derive(clap::ValueEnum, Debug, Copy, Clone)]
-pub enum Listen {
-	/// Latest finalized head of the canonical chain.
-	Finalized,
-	/// Latest head of the canonical chain.
-	Head,
 }
 
 impl fmt::Display for Chain {
@@ -183,127 +88,4 @@ impl TryFrom<subxt::rpc::types::RuntimeVersion> for Chain {
 		chain.make_ascii_lowercase();
 		Chain::from_str(&chain)
 	}
-}
-
-#[derive(Debug, Clone, Parser)]
-#[cfg_attr(test, derive(PartialEq))]
-pub struct MonitorConfig {
-	/// They type of event to listen to.
-	///
-	/// Typically, finalized is safer and there is no chance of anything going wrong, but it can be
-	/// slower. It is recommended to use finalized, if the duration of the signed phase is longer
-	/// than the the finality delay.
-	#[clap(long, value_enum, default_value_t = Listen::Head)]
-	pub listen: Listen,
-
-	/// The solver algorithm to use.
-	#[clap(subcommand)]
-	pub solver: Solver,
-
-	/// Submission strategy to use.
-	///
-	/// Possible options:
-	///
-	/// `--submission-strategy if-leading`: only submit if leading.
-	///
-	/// `--submission-strategy always`: always submit.
-	///
-	/// `--submission-strategy "percent-better <percent>"`: submit if the submission is `n` percent better.
-	///
-	/// `--submission-strategy "no-worse-than  <percent>"`: submit if submission is no more than `n` percent worse.
-	#[clap(long, parse(try_from_str), default_value = "if-leading")]
-	pub submission_strategy: SubmissionStrategy,
-
-	/// The path to a file containing the seed of the account. If the file is not found, the seed is
-	/// used as-is.
-	///
-	/// Can also be provided via the `SEED` environment variable.
-	///
-	/// WARNING: Don't use an account with a large stash for this. Based on how the bot is
-	/// configured, it might re-try and lose funds through transaction fees/deposits.
-	#[clap(long, short, env = "SEED")]
-	pub seed_or_path: String,
-
-	/// Delay in number seconds to wait until starting mining a solution.
-	///
-	/// At every block when a solution is attempted
-	/// a delay can be enforced to avoid submitting at
-	/// "same time" and risk potential races with other miners.
-	///
-	/// When this is enabled and there are competing solutions, your solution might not be submitted
-	/// if the scores are equal.
-	#[clap(long, default_value_t = 0)]
-	pub delay: usize,
-
-	/// Verify the submission by `dry-run` the extrinsic to check the validity.
-	/// If the extrinsic is invalid then the submission is ignored and the next block will attempted again.
-	///
-	/// This requires a RPC endpoint that exposes unsafe RPC methods, if the RPC endpoint doesn't expose unsafe RPC methods
-	/// then the miner will be terminated.
-	#[clap(long)]
-	pub dry_run: bool,
-}
-
-#[derive(Debug, Clone, Parser)]
-#[cfg_attr(test, derive(PartialEq))]
-pub struct EmergencySolutionConfig {
-	/// The block hash at which scraping happens. If none is provided, the latest head is used.
-	#[clap(long)]
-	pub at: Option<Hash>,
-
-	/// The solver algorithm to use.
-	#[clap(subcommand)]
-	pub solver: Solver,
-
-	/// The number of top backed winners to take. All are taken, if not provided.
-	pub take: Option<usize>,
-}
-
-#[derive(Debug, Clone, Parser)]
-#[cfg_attr(test, derive(PartialEq))]
-pub struct DryRunConfig {
-	/// The block hash at which scraping happens. If none is provided, the latest head is used.
-	#[clap(long)]
-	pub at: Option<Hash>,
-
-	/// The solver algorithm to use.
-	#[clap(subcommand)]
-	pub solver: Solver,
-
-	/// Force create a new snapshot, else expect one to exist onchain.
-	#[clap(long)]
-	pub force_snapshot: bool,
-
-	/// The path to a file containing the seed of the account. If the file is not found, the seed is
-	/// used as-is.
-	///
-	/// Can also be provided via the `SEED` environment variable.
-	///
-	/// WARNING: Don't use an account with a large stash for this. Based on how the bot is
-	/// configured, it might re-try and lose funds through transaction fees/deposits.
-	#[clap(long, short, env = "SEED")]
-	pub seed_or_path: String,
-}
-
-#[derive(Debug, Clone, Parser)]
-#[cfg_attr(test, derive(PartialEq))]
-#[clap(author, version, about)]
-pub struct Opt {
-	/// The `ws` node to connect to.
-	#[clap(long, short, default_value = DEFAULT_URI, env = "URI")]
-	pub uri: String,
-
-	#[clap(subcommand)]
-	pub command: Command,
-
-	/// The prometheus endpoint TCP port.
-	#[clap(long, short, env = "PROMETHEUS_PORT")]
-	pub prometheus_port: Option<u16>,
-
-	/// Sets a custom logging filter. Syntax is `<target>=<level>`, e.g. -lstaking-miner=debug.
-	///
-	/// Log levels (least to most verbose) are error, warn, info, debug, and trace.
-	/// By default, all targets log `info`. The global log level can be set with `-l<level>`.
-	#[clap(long, short, default_value = "info")]
-	pub log: String,
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,12 +21,10 @@
 //! needing to sprinkle `any_runtime` in a few extra places.
 
 // re-exports.
-pub use crate::{error::Error, opt::*};
+// pub use crate::error::Error;
 pub use frame_election_provider_support::VoteWeight;
 pub use pallet_election_provider_multi_phase::{Miner, MinerConfig};
 pub use subxt::ext::sp_core;
-
-use once_cell::sync::OnceCell;
 
 /// The account id type.
 pub type AccountId = subxt::utils::AccountId32;
@@ -98,4 +96,4 @@ pub type SignedSubmission<S> =
 )]
 pub mod runtime {}
 
-pub static SHARED_CLIENT: OnceCell<SubxtClient> = OnceCell::new();
+pub static SHARED_CLIENT: once_cell::sync::OnceCell<SubxtClient> = once_cell::sync::OnceCell::new();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,7 +21,6 @@
 //! needing to sprinkle `any_runtime` in a few extra places.
 
 // re-exports.
-// pub use crate::error::Error;
 pub use frame_election_provider_support::VoteWeight;
 pub use pallet_election_provider_multi_phase::{Miner, MinerConfig};
 pub use subxt::ext::sp_core;

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -16,7 +16,7 @@
 
 //! Wrappers around creating a signer account.
 
-use crate::prelude::*;
+use crate::{error::Error, prelude::*};
 use sp_core::Pair as _;
 use subxt::tx::Signer as _;
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-use staking_miner::prelude::Chain;
+use staking_miner::opt::Chain;
 use std::{
 	io::{BufRead, BufReader, Read},
 	ops::{Deref, DerefMut},


### PR DESCRIPTION
This is a slightly opinionated reshuffle of things to:
- Make it clear what the main entry points (subcommands) are by putting them into a `commands` module.
- Put the options for each subcommand next to it (thinning out the `opts` module somewhat; maybe we can go fruther because not everything in that is related to CLI opts by the looks of it).
- Remove a couple of things from `prelude` (just because personally I think it's easier to write but harder to read/follow where things come from when `prelude::*` is used for too many imports).

What do you reckon?