### PR TITLE
change `submission strategy == if leading` to not submit equal score

### DIFF
--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -609,8 +609,7 @@ pub(crate) fn score_passes_strategy(
 	match strategy {
 		SubmissionStrategy::Always => true,
 		SubmissionStrategy::IfLeading =>
-			our_score == best_score ||
-				our_score.strict_threshold_better(best_score, Perbill::zero()),
+			our_score.strict_threshold_better(best_score, Perbill::zero()),
 		SubmissionStrategy::ClaimBetterThan(epsilon) =>
 			our_score.strict_threshold_better(best_score, epsilon),
 		SubmissionStrategy::ClaimNoWorseThan(epsilon) =>
@@ -656,12 +655,12 @@ mod tests {
 		assert!(score_passes_strategy(s(5), s(10), SubmissionStrategy::Always));
 
 		// if leading
-		assert!(score_passes_strategy(s(0), s(0), SubmissionStrategy::IfLeading));
+		assert!(!score_passes_strategy(s(0), s(0), SubmissionStrategy::IfLeading));
 		assert!(score_passes_strategy(s(1), s(0), SubmissionStrategy::IfLeading));
 		assert!(score_passes_strategy(s(2), s(0), SubmissionStrategy::IfLeading));
 		assert!(!score_passes_strategy(s(5), s(10), SubmissionStrategy::IfLeading));
 		assert!(!score_passes_strategy(s(9), s(10), SubmissionStrategy::IfLeading));
-		assert!(score_passes_strategy(s(10), s(10), SubmissionStrategy::IfLeading));
+		assert!(!score_passes_strategy(s(10), s(10), SubmissionStrategy::IfLeading));
 
 		// if better by 2%
 		assert!(!score_passes_strategy(s(50), s(100), SubmissionStrategy::ClaimBetterThan(two)));


### PR DESCRIPTION
This code was copied from the staking-miner v1 but I think `submission strategy == if leading`  should really only submit if the score is strictly better than existing scores on chain. 

Thus, this is confusing and not a good default strategy such as if there is already a solution with the same score one might lose transaction fee when submitting then.

This boils down to whether one trusts that previous scores are legit or not but as we already have `submission strategy == always` that can be used if one doesn't trust the scores on chain.

//cc @kianenigma do you remember why we did it like that? 
