### PR TITLE
ci: copy new polkadot binaries to `/usr/bin`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,8 @@ nightly-test:
     - cargo build --release --features fast-runtime
     - mkdir -p ~/.local/bin
     - mv ./target/release/polkadot /usr/bin
+    - mv ./target/release/polkadot-execute-worker /usr/bin
+    - mv ./target/release/polkadot-prepare-worker /usr/bin
     - polkadot --version
     - cd -
     - rm -rf polkadot


### PR DESCRIPTION
https://github.com/paritytech/polkadot/pull/7337 changed that polkadot requires three binaries which is required for the integration tests.

Close #642 