### PR TITLE
tests: disable integration tests `polkadot-dev`

### DIFF
--- a/tests/monitor.rs
+++ b/tests/monitor.rs
@@ -16,7 +16,8 @@ use std::{process, time::Instant};
 #[tokio::test]
 async fn submit_monitor_works_basic() {
 	init_logger();
-	test_submit_solution(Target::Node(Chain::Polkadot)).await;
+	// TODO: https://github.com/paritytech/staking-miner-v2/issues/673
+	// test_submit_solution(Target::Node(Chain::Polkadot)).await;
 	test_submit_solution(Target::Node(Chain::Kusama)).await;
 	test_submit_solution(Target::Node(Chain::Westend)).await;
 	test_submit_solution(Target::StakingMinerPlayground).await;


### PR DESCRIPTION
Currently, the polkadot binary doesn't provide the chainspec for `polkadot-dev` anymore
and this PR disabled it for the integration tests.

However, `kusama-dev` and `westend-dev` is still available but the `kusama-dev` will also be removed soon