### PR TITLE
tests: fix integration tests

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -100,6 +100,7 @@ pub fn run_polkadot_node(chain: Chain) -> (KillChildOnDrop, String) {
 				"--execution",
 				"Native",
 				"--offchain-worker=Never",
+				"--rpc-cors=all",
 			])
 			.spawn()
 			.unwrap(),


### PR DESCRIPTION
Close #710

The connection was rejected by CORS and I don't really understand why but we are not really trying to test that, thus CORS is disabled  on rpc server.