### PR TITLE
rename project to polkadot-staking-miner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3282,6 +3282,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
+name = "polkadot-staking-miner"
+version = "1.2.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "frame-election-provider-support",
+ "frame-support",
+ "futures",
+ "hyper",
+ "jsonrpsee",
+ "log",
+ "once_cell",
+ "pallet-election-provider-multi-phase",
+ "parity-scale-codec",
+ "pin-project-lite",
+ "prometheus",
+ "regex",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-npos-elections",
+ "sp-runtime 29.0.0",
+ "sp-storage 17.0.0",
+ "subxt",
+ "thiserror",
+ "tokio",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,38 +5278,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "staking-miner"
-version = "1.2.0"
-dependencies = [
- "anyhow",
- "assert_cmd",
- "clap",
- "frame-election-provider-support",
- "frame-support",
- "futures",
- "hyper",
- "jsonrpsee",
- "log",
- "once_cell",
- "pallet-election-provider-multi-phase",
- "parity-scale-codec",
- "pin-project-lite",
- "prometheus",
- "regex",
- "scale-info",
- "scale-value",
- "serde",
- "serde_json",
- "sp-npos-elections",
- "sp-runtime 29.0.0",
- "sp-storage 17.0.0",
- "subxt",
- "thiserror",
- "tokio",
- "tracing-subscriber 0.3.18",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-name = "staking-miner"
+name = "polkadot-staking-miner"
 version = "1.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
+rust-version = "1.70.0"
+license = "GPL-3.0"
+repository = "https://github.com/paritytech/staking-miner-v2"
+homepage = "https://www.parity.io/"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }


### PR DESCRIPTION
We have reserved `polkadot-staking-miner` on crates.io because `staking-miner` was reserved already.

To able to publish to binary to crates.io the project has to renamed to polkadot-staking-miner is that okay?
We could keep binary name to `staking-miner` but I think that is confusing, so all good to call it "polkadot-staking-miner"?

Close #680 